### PR TITLE
Fix

### DIFF
--- a/src/components/atoms/logout-button/LogoutButton.tsx
+++ b/src/components/atoms/logout-button/LogoutButton.tsx
@@ -7,12 +7,12 @@ const LogoutButton = () => {
   };
 
   return (
-    <div
+    <button
       onClick={clickHandler}
       className="user-panel-button cursor-pointer hover:border-blue focus:outline-blue"
     >
       <span className="w-24 select-none text-center">ログアウト</span>
-    </div>
+    </button>
   );
 };
 

--- a/src/components/atoms/logout-button/__snapshots__/LogoutButton.test.tsx.snap
+++ b/src/components/atoms/logout-button/__snapshots__/LogoutButton.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`LogoutButtonの単体テスト スナップショットテスト 1`] = `
 <div>
-  <div
+  <button
     class="user-panel-button cursor-pointer hover:border-blue focus:outline-blue"
   >
     <span
@@ -10,6 +10,6 @@ exports[`LogoutButtonの単体テスト スナップショットテスト 1`] = 
     >
       ログアウト
     </span>
-  </div>
+  </button>
 </div>
 `;


### PR DESCRIPTION
### ログアウトボタンにフォーカスが当たらない問題を修正しました
具体的にはdivタグでマークアップされていたログアウトボタンをbuttonタグに変更しています。

```typescript
    <div
      onClick={clickHandler}
      className="user-panel-button cursor-pointer hover:border-blue focus:outline-blue"
    >
      <span className="w-24 select-none text-center">ログアウト</span>
    </div>
```
こちらの実装を

```typescript
    <button
      onClick={clickHandler}
      className="user-panel-button cursor-pointer hover:border-blue focus:outline-blue"
    >
      <span className="w-24 select-none text-center">ログアウト</span>
    </button>
``` 
この通りbuttonタグに変更しています。